### PR TITLE
Choose migration dir

### DIFF
--- a/slmigrate/arghandler.py
+++ b/slmigrate/arghandler.py
@@ -37,5 +37,6 @@ def determine_migrate_action(arguments):
             services_to_migrate.append((service, action))
     return services_to_migrate
 
+
 def determin_migration_dir(arguments):
     constants.migration_dir = getattr(arguments, constants.migration_arg)

--- a/slmigrate/arghandler.py
+++ b/slmigrate/arghandler.py
@@ -12,14 +12,17 @@ def parse_arguments(args):
     parser.add_argument("--" + constants.fis.arg, "--file", "--files", help="Migrate ingested files", action="store_true")
     parser.add_argument("--" + constants.testmonitor.arg, "--test", "--tests", "--testmonitor", help="Migrate Test Monitor Data", action="store_true")
     parser.add_argument("--" + constants.alarmrule.arg, "--alarms", "--alarm", help="Migrate Tag alarm rules", action="store_true")
+    parser.add_argument("--" + constants.migration_arg, "--directory", "--folder", help="Specify the directory used for migrated data", action="store", default=constants.migration_dir)
     return parser
 
 
 def handle_unallowed_args(arguments):
     if not(arguments.capture) and not(arguments.restore):
         print("Please use --capture or --restore to determine which direction the migration is occuring. ")
+        exit()
     if arguments.capture and arguments.restore:
         print("You cannot use --capture and --restore simultaneously. ")
+        exit()
 
 
 def determine_migrate_action(arguments):
@@ -29,7 +32,10 @@ def determine_migrate_action(arguments):
     elif arguments.restore:
         action = constants.restore_arg
     for arg in vars(arguments):
-        if (getattr(arguments, arg) and not ((arg == constants.capture_arg) or (arg == constants.restore_arg))):
+        if (getattr(arguments, arg) and not ((arg == constants.capture_arg) or (arg == constants.restore_arg) or (arg == constants.migration_arg))):
             service = getattr(constants, arg)
             services_to_migrate.append((service, action))
     return services_to_migrate
+
+def determin_migration_dir(arguments):
+    constants.migration_dir = getattr(arguments, constants.migration_arg)

--- a/slmigrate/constants.py
+++ b/slmigrate/constants.py
@@ -3,7 +3,8 @@ from types import SimpleNamespace
 
 # Global Path Constants
 migration_dir = os.path.join(os.path.abspath(os.sep), "migration")
-no_sql_dump_dir = os.path.join(migration_dir, "mongo-dump")
+migration_arg = "dir"
+# no_sql_dump_dir = os.path.join(migration_dir, "mongo-dump")
 program_file_dir = os.environ.get("ProgramW6432")
 program_data_dir = os.environ.get("ProgramData")
 

--- a/slmigrate/filehandler.py
+++ b/slmigrate/filehandler.py
@@ -4,21 +4,28 @@ import os
 import shutil
 
 
+def determine_migration_dir(service):
+    migration_dir = os.path.join(constants.migration_dir, service.name)
+    return migration_dir
+
+
 def check_migration_dir(dir):
     if (os.path.isdir(dir)):
         shutil.rmtree(dir)
+    
 
 
 def migrate_singlefile(service, action):
     if not service.singlefile_migration:
         return
+    migration_dir = determine_migration_dir(service)
     if action == constants.capture_arg:
-        check_migration_dir(service.singlefile_migration_dir)
-        os.mkdir(service.singlefile_migration_dir)
-        singlefile_full_path = os.path.join(constants.program_data_dir, "National Instruments", "Skyline", "KeyValueDatabase", service.singlefile_to_migrate)
-        shutil.copy(singlefile_full_path, service.singlefile_migration_dir)
+        check_migration_dir(migration_dir)
+        os.mkdir(migration_dir)
+        singlefile_full_path = os.path.join(constants.program_data_dir,service.singlefile_source_dir, service.singlefile_to_migrate)
+        shutil.copy(singlefile_full_path, migration_dir)
     elif action == constants.restore_arg:
-        singlefile_full_path = os.path.join(service.singlefile_migration_dir, service.singlefile_to_migrate)
+        singlefile_full_path = os.path.join(migration_dir, service.singlefile_to_migrate)
         shutil.copy(singlefile_full_path, service.singlefile_source_dir)
 
 
@@ -26,7 +33,8 @@ def migrate_dir(service, action):
     if not service.directory_migration:
         return
     if action == constants.capture_arg:
-        check_migration_dir(service.migration_dir)
-        shutil.copytree(service.source_dir, service.migration_dir)
+        migratation_dir  = determine_migration_dir(service)
+        check_migration_dir(migratation_dir)
+        shutil.copytree(service.source_dir, migratation_dir)
     elif action == constants.restore_arg:
-        dir_util.copy_tree(service.migration_dir, service.source_dir)
+        dir_util.copy_tree(migratation_dir, service.source_dir)

--- a/slmigrate/filehandler.py
+++ b/slmigrate/filehandler.py
@@ -12,7 +12,6 @@ def determine_migration_dir(service):
 def check_migration_dir(dir):
     if (os.path.isdir(dir)):
         shutil.rmtree(dir)
-    
 
 
 def migrate_singlefile(service, action):
@@ -22,7 +21,7 @@ def migrate_singlefile(service, action):
     if action == constants.capture_arg:
         check_migration_dir(migration_dir)
         os.mkdir(migration_dir)
-        singlefile_full_path = os.path.join(constants.program_data_dir,service.singlefile_source_dir, service.singlefile_to_migrate)
+        singlefile_full_path = os.path.join(constants.program_data_dir, service.singlefile_source_dir, service.singlefile_to_migrate)
         shutil.copy(singlefile_full_path, migration_dir)
     elif action == constants.restore_arg:
         singlefile_full_path = os.path.join(migration_dir, service.singlefile_to_migrate)
@@ -33,7 +32,7 @@ def migrate_dir(service, action):
     if not service.directory_migration:
         return
     if action == constants.capture_arg:
-        migratation_dir  = determine_migration_dir(service)
+        migratation_dir = determine_migration_dir(service)
         check_migration_dir(migratation_dir)
         shutil.copytree(service.source_dir, migratation_dir)
     elif action == constants.restore_arg:

--- a/slmigrate/mongohandler.py
+++ b/slmigrate/mongohandler.py
@@ -11,9 +11,10 @@ def get_service_config(service, test=False):
 
 
 def migrate_mongo_cmd(service, action, config):
-    mongo_dump_file = os.path.join(constants.no_sql_dump_dir, config[service.name]['Mongo.Database'])
+    mongo_migration_dir = os.path.join(constants.migration_dir, "mongo-dump")
+    mongo_dump_file = os.path.join(mongo_migration_dir, config[service.name]['Mongo.Database'])
     if action == constants.capture_arg:
-        cmd_to_run = constants.mongo_dump + " --port " + str(config[service.name]['Mongo.Port']) + " --db " + config[service.name]['Mongo.Database'] + " --username " + config[service.name]['Mongo.User'] + " --password " + config[service.name]['Mongo.Password'] + " --out " + constants.no_sql_dump_dir + " --gzip"
+        cmd_to_run = constants.mongo_dump + " --port " + str(config[service.name]['Mongo.Port']) + " --db " + config[service.name]['Mongo.Database'] + " --username " + config[service.name]['Mongo.User'] + " --password " + config[service.name]['Mongo.Password'] + " --out " + mongo_migration_dir + " --gzip"
     if action == constants.restore_arg:
         cmd_to_run = constants.mongo_restore + " --port " + str(config[service.name]['Mongo.Port']) + " --db " + config[service.name]['Mongo.Database'] + " --username " + config[service.name]['Mongo.User'] + " --password " + config[service.name]['Mongo.Password'] + " --gzip " + mongo_dump_file
     subprocess.run(cmd_to_run)

--- a/slmigrate/servicemgrhandler.py
+++ b/slmigrate/servicemgrhandler.py
@@ -10,9 +10,10 @@ def stop_sl_service(service):
 
 
 def stop_all_sl_services():
-    print("Stopping all SystemLink services")
+    print("Stopping all SystemLink services...")
     subprocess.run(constants.slconf_cmd_stop_all)
 
 
 def start_all_sl_services():
+    print("Starting all SystemLink services")
     subprocess.run(constants.slconf_cmd_start_all)

--- a/systemlinkmigrate.py
+++ b/systemlinkmigrate.py
@@ -8,6 +8,7 @@ from slmigrate import mongohandler, filehandler, arghandler, servicemgrhandler, 
 if __name__ == "__main__":
     arguments = arghandler.parse_arguments(sys.argv[1:]).parse_args()
     arghandler.handle_unallowed_args(arguments)
+    arghandler.determin_migration_dir(arguments)
     servicemgrhandler.stop_all_sl_services()
     mongo_proc = mongohandler.start_mongo(constants.mongod_exe, constants.mongo_config)
     services_to_migrate = arghandler.determine_migrate_action(arguments)

--- a/test/test_constants.py
+++ b/test/test_constants.py
@@ -8,15 +8,18 @@ mongo_config = os.path.join(os.getcwd(), "test", "testmongo.conf")
 mongo_dump = os.path.join(root_dir, "MongoDB", "bin", "mongodump.exe")
 mongo_restore = os.path.join(root_dir, "MongoDB", "bin", "mongod.exe", "mongorestore.exe")
 service_config_dir = os.path.join(os.getcwd(), "test")
+migration_dir = os.path.join(os.path.abspath(os.sep), "migration_test")
 
 test_dict = {
     'arg': 'test',
     'name': "local",
-    'directory_migration': False,
+    'directory_migration': True,
     'singlefile_migration': True,
     'require_service_restart': False,
-    'singlefile_migration_dir': os.path.join(os.path.abspath(os.sep), "migration_test_dir"),
+    'singlefile_migration_dir': os.path.join(os.path.abspath(os.sep), "migration_test"),
     'singlefile_source_dir': os.path.join(os.path.abspath(os.sep), "source_test_dir"),
-    'singlefile_to_migrate': os.path.join(os.path.abspath(os.sep), "source_test_dir", "demofile2.txt")
+    'singlefile_to_migrate': os.path.join(os.path.abspath(os.sep), "source_test_dir", "demofile2.txt"),
+    'migration_dir': os.path.join(migration_dir, "local"),
+    # 'source_dir': os.path.join(os.path.abspath(os.sep), "source_test_dir")
 }
 test_service = SimpleNamespace(**test_dict)

--- a/test/test_constants.py
+++ b/test/test_constants.py
@@ -20,6 +20,6 @@ test_dict = {
     'singlefile_source_dir': os.path.join(os.path.abspath(os.sep), "source_test_dir"),
     'singlefile_to_migrate': os.path.join(os.path.abspath(os.sep), "source_test_dir", "demofile2.txt"),
     'migration_dir': os.path.join(migration_dir, "local"),
-    # 'source_dir': os.path.join(os.path.abspath(os.sep), "source_test_dir")
+    'source_dir': os.path.join(os.path.abspath(os.sep), "source_test_dir")
 }
 test_service = SimpleNamespace(**test_dict)

--- a/test/test_slmigrate.py
+++ b/test/test_slmigrate.py
@@ -17,6 +17,7 @@ def test_capture_migrate_mongo_data():
     constants.mongo_config = test_constants.mongo_config
     constants.mongo_dump = test_constants.mongo_dump
     constants.mongo_restore = test_constants.mongo_restore
+    constants.migration_dir = test_constants.migration_dir
     constants.service_config_dir = test_constants.service_config_dir
     mongo_process = mongohandler.start_mongo(test_constants.mongod_exe, test_constants.mongo_config)
     test_service = test_constants.test_service
@@ -36,51 +37,34 @@ def check_migration_dir():
 
 
 def test_capture_migrate_dir():
-    # test_dict = {
-    #     'arg': 'test',
-    #     'service_nanme': "test",
-    #     'directory_migration': True,
-    #     'singlefile_migration': False,
-    #     'require_service_restart': False,
-    #     'migration_dir': os.path.join(os.path.abspath(os.sep), "mig_test_dir"),
-    #     'source_dir': os.path.join(os.path.abspath(os.sep), "source_test_dir")
-    # }
-    # test = SimpleNamespace(**test_dict)
     test = test_constants.test_service
+    constants.migration_dir = test_constants.migration_dir
     if os.path.isdir(test.migration_dir):
         shutil.rmtree(test.migration_dir)
     if os.path.isdir(test.source_dir):
         shutil.rmtree(test.source_dir)
-    os.mkdir(test.migration_dir)
     os.mkdir(test.source_dir)
     os.mkdir(os.path.join(test.source_dir, "lev1"))
     os.mkdir(os.path.join(test.source_dir, "lev1", "lev2"))
     filehandler.migrate_dir(test, constants.capture_arg)
-    assert os.path.isdir(os.path.join(test.migration_dir, "lev1", "lev2"))
+    assert os.path.isdir(os.path.join(constants.migration_dir, test.name, "lev1", "lev2"))
+    shutil.rmtree(test.source_dir)
+    shutil.rmtree(constants.migration_dir)
+
 
 
 def test_capture_migrate_singlefile():
-    # test_dict = {
-    #     'arg': 'test',
-    #     'service_name': "test",
-    #     'directory_migration': False,
-    #     'singlefile_migration': True,
-    #     'require_service_restart': False,
-    #     'singlefile_migration_dir': os.path.join(os.path.abspath(os.sep), "migration_test_dir"),
-    #     'singlefile_source_dir': os.path.join(os.path.abspath(os.sep), "source_test_dir"),
-    #     'singlefile_to_migrate': os.path.join(os.path.abspath(os.sep), "source_test_dir", "demofile2.txt")
-    # }
-    # test = SimpleNamespace(**test_dict)
     constants.migration_dir = test_constants.migration_dir
     test = test_constants.test_service
     if os.path.isdir(test.singlefile_migration_dir):
         shutil.rmtree(test.singlefile_migration_dir)
     if os.path.isdir(test.singlefile_source_dir):
         shutil.rmtree(test.singlefile_source_dir)
-    # os.mkdir(test.singlefile_migration_dir)
     os.mkdir(test.singlefile_source_dir)
     os.mkdir(constants.migration_dir)
     test_file = open(os.path.join(test.singlefile_source_dir, "demofile2.txt"), "a")
     test_file.close()
     filehandler.migrate_singlefile(test, constants.capture_arg)
     assert os.path.isfile(os.path.join(test.migration_dir,  "demofile2.txt"))
+    shutil.rmtree(test.source_dir)
+    shutil.rmtree(constants.migration_dir)

--- a/test/test_slmigrate.py
+++ b/test/test_slmigrate.py
@@ -5,7 +5,6 @@ import slmigrate.mongohandler as mongohandler
 import slmigrate.arghandler as arghandler
 import slmigrate.filehandler as filehandler
 from test import test_constants
-from types import SimpleNamespace
 
 
 def test_parse_arguments():
@@ -52,7 +51,6 @@ def test_capture_migrate_dir():
     shutil.rmtree(constants.migration_dir)
 
 
-
 def test_capture_migrate_singlefile():
     constants.migration_dir = test_constants.migration_dir
     test = test_constants.test_service
@@ -65,6 +63,6 @@ def test_capture_migrate_singlefile():
     test_file = open(os.path.join(test.singlefile_source_dir, "demofile2.txt"), "a")
     test_file.close()
     filehandler.migrate_singlefile(test, constants.capture_arg)
-    assert os.path.isfile(os.path.join(test.migration_dir,  "demofile2.txt"))
+    assert os.path.isfile(os.path.join(test.migration_dir, "demofile2.txt"))
     shutil.rmtree(test.source_dir)
     shutil.rmtree(constants.migration_dir)

--- a/test/test_slmigrate.py
+++ b/test/test_slmigrate.py
@@ -36,16 +36,17 @@ def check_migration_dir():
 
 
 def test_capture_migrate_dir():
-    test_dict = {
-        'arg': 'test',
-        'service_nanme': "test",
-        'directory_migration': True,
-        'singlefile_migration': False,
-        'require_service_restart': False,
-        'migration_dir': os.path.join(os.path.abspath(os.sep), "mig_test_dir"),
-        'source_dir': os.path.join(os.path.abspath(os.sep), "source_test_dir")
-    }
-    test = SimpleNamespace(**test_dict)
+    # test_dict = {
+    #     'arg': 'test',
+    #     'service_nanme': "test",
+    #     'directory_migration': True,
+    #     'singlefile_migration': False,
+    #     'require_service_restart': False,
+    #     'migration_dir': os.path.join(os.path.abspath(os.sep), "mig_test_dir"),
+    #     'source_dir': os.path.join(os.path.abspath(os.sep), "source_test_dir")
+    # }
+    # test = SimpleNamespace(**test_dict)
+    test = test_constants.test_service
     if os.path.isdir(test.migration_dir):
         shutil.rmtree(test.migration_dir)
     if os.path.isdir(test.source_dir):
@@ -59,24 +60,27 @@ def test_capture_migrate_dir():
 
 
 def test_capture_migrate_singlefile():
-    test_dict = {
-        'arg': 'test',
-        'service_nanme': "test",
-        'directory_migration': False,
-        'singlefile_migration': True,
-        'require_service_restart': False,
-        'singlefile_migration_dir': os.path.join(os.path.abspath(os.sep), "migration_test_dir"),
-        'singlefile_source_dir': os.path.join(os.path.abspath(os.sep), "source_test_dir"),
-        'singlefile_to_migrate': os.path.join(os.path.abspath(os.sep), "source_test_dir", "demofile2.txt")
-    }
-    test = SimpleNamespace(**test_dict)
+    # test_dict = {
+    #     'arg': 'test',
+    #     'service_name': "test",
+    #     'directory_migration': False,
+    #     'singlefile_migration': True,
+    #     'require_service_restart': False,
+    #     'singlefile_migration_dir': os.path.join(os.path.abspath(os.sep), "migration_test_dir"),
+    #     'singlefile_source_dir': os.path.join(os.path.abspath(os.sep), "source_test_dir"),
+    #     'singlefile_to_migrate': os.path.join(os.path.abspath(os.sep), "source_test_dir", "demofile2.txt")
+    # }
+    # test = SimpleNamespace(**test_dict)
+    constants.migration_dir = test_constants.migration_dir
+    test = test_constants.test_service
     if os.path.isdir(test.singlefile_migration_dir):
         shutil.rmtree(test.singlefile_migration_dir)
     if os.path.isdir(test.singlefile_source_dir):
         shutil.rmtree(test.singlefile_source_dir)
-    os.mkdir(test.singlefile_migration_dir)
+    # os.mkdir(test.singlefile_migration_dir)
     os.mkdir(test.singlefile_source_dir)
+    os.mkdir(constants.migration_dir)
     test_file = open(os.path.join(test.singlefile_source_dir, "demofile2.txt"), "a")
     test_file.close()
     filehandler.migrate_singlefile(test, constants.capture_arg)
-    assert os.path.isfile(os.path.join(test.singlefile_migration_dir, "demofile2.txt"))
+    assert os.path.isfile(os.path.join(test.migration_dir,  "demofile2.txt"))


### PR DESCRIPTION
- users can now specify a output/input migration directory by using the --dir="<directory>" argument
- Minor updates to functions to leverage the new parameter
- Updates to tests to use new parameter and also use test service used in other tests
- test now cleanup after themself 