### PR TITLE
Smtp state userdata notification

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ The following services can be migrated with this utility:
 - Asset Management: `--asset`
     - Cannot migrate between 2020R1 and 2020R2 due to changes in database format
 - Repository: `--repo`
+- UserData: `--userdata`
 
 ...with more on the way.
 

--- a/README.md
+++ b/README.md
@@ -44,13 +44,20 @@ The following services can be migrated with this utility:
 - File Ingestion: `--file`
 - Test Monitor: `--test`
 - Asset Management: `--asset`
-    - Cannot migrate between 2020R1 and 2020R2 due to changes in database format
+    - Cannot be migrated between 2020R1 and 2020R2 servers
 - Repository: `--repo`
-- UserData: `--userdata`
+    - Feeds may require additional updates if servers used for migration have different domain names
+- User Data: `--userdata`
 - Notifications: `--notification`
-- States: `--states`
+
+    - Feeds may require additional updates if servers used for migration have different domain names
+    - Cannot be migrated between 2020R1 and 2020R2 servers
 
 ...with more on the way.
+
+#### Service Not Supported
+The following list of services is explicitly not supported because of issues that arose when developing and testing migrating the service that will require changes to the service rather than the migration utility to enable support. 
+- Cloud Connector
 
 ## Specifying a Migration Directory
 By default this tool will migrate data into the directory `C:\migrate`. During *capture* this directory is created. During *restore* this directory is expected to be present. The `--dir` argument allows for other directories and locations to be specified. For example:

--- a/README.md
+++ b/README.md
@@ -2,7 +2,9 @@
 
 ## Prerequisites 
 ### SystemLink
-- These scripts assume migration from a SystemLink 2020R1 (20.0) to another SystemLink 2020R1 server 
+- These scripts assume migration from a SystemLink 2020R1 (20.0) to another SystemLink 2020R1 or 2020R2 server 
+    - **We assume the server you are migrating to is clean with no data. Migrating to a server with existing data will result in data loss.**
+    - Not all services can be migrated from a 2020R1 server to a 2020R2 server. Please review **Supported Services** for details
 - These scripts assume a single-box SystemLink installation. 
 - These scripts are designed to run on the same machines as the SystemLink installation. They do not support remote migration.
 
@@ -49,7 +51,7 @@ The following services can be migrated with this utility:
     - Feeds may require additional updates if servers used for migration have different domain names
 - User Data: `--userdata`
 - Notifications: `--notification`
-
+- States: `--states`
     - Feeds may require additional updates if servers used for migration have different domain names
     - Cannot be migrated between 2020R1 and 2020R2 servers
 

--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ The following services can be migrated with this utility:
     - Cannot migrate between 2020R1 and 2020R2 due to changes in database format
 - Repository: `--repo`
 - UserData: `--userdata`
+- Notifications: `--notification`
+- States: `--states`
 
 ...with more on the way.
 

--- a/slmigrate/arghandler.py
+++ b/slmigrate/arghandler.py
@@ -14,6 +14,7 @@ def parse_arguments(args):
     parser.add_argument("--" + constants.asset.arg, "--assets", help="Migrate asset utilitization and calibration data", action="store_true")
     parser.add_argument("--" + constants.repository.arg, "--repo", help="Migrate packages and feeds", action="store_true")
     parser.add_argument("--" + constants.alarmrule.arg, "--alarms", "--alarm", help="Migrate Tag alarm rules", action="store_true")
+    parser.add_argument("--" + constants.userdata.arg, "--ud", help="Migrate user data", action="store_true")
     parser.add_argument("--" + constants.migration_arg, "--directory", "--folder", help="Specify the directory used for migrated data", action="store", default=constants.migration_dir)
     
     return parser

--- a/slmigrate/arghandler.py
+++ b/slmigrate/arghandler.py
@@ -18,7 +18,6 @@ def parse_arguments(args):
     parser.add_argument("--" + constants.notification.arg, "--notifications", help="Migrate notifications strategies, templates, and groups", action="store_true")
     parser.add_argument("--" + constants.states.arg, "--state", help="Migrate system states", action="store_true")
     parser.add_argument("--" + constants.migration_arg, "--directory", "--folder", help="Specify the directory used for migrated data", action="store", default=constants.migration_dir)
-    
     return parser
 
 

--- a/slmigrate/arghandler.py
+++ b/slmigrate/arghandler.py
@@ -15,6 +15,8 @@ def parse_arguments(args):
     parser.add_argument("--" + constants.repository.arg, "--repo", help="Migrate packages and feeds", action="store_true")
     parser.add_argument("--" + constants.alarmrule.arg, "--alarms", "--alarm", help="Migrate Tag alarm rules", action="store_true")
     parser.add_argument("--" + constants.userdata.arg, "--ud", help="Migrate user data", action="store_true")
+    parser.add_argument("--" + constants.notification.arg, "--notifications", help="Migrate notifications strategies, templates, and groups", action="store_true")
+    parser.add_argument("--" + constants.states.arg, "--state", help="Migrate system states", action="store_true")
     parser.add_argument("--" + constants.migration_arg, "--directory", "--folder", help="Specify the directory used for migrated data", action="store", default=constants.migration_dir)
     
     return parser

--- a/slmigrate/constants.py
+++ b/slmigrate/constants.py
@@ -87,6 +87,14 @@ repository_dict = {
 }
 repository = SimpleNamespace(**repository_dict)
 
+userdata_dict = {
+    'arg': 'userdata',
+    'name': "UserData",
+    'directory_migration': False,
+    'singlefile_migration': False,
+}
+userdata = SimpleNamespace(**userdata_dict)
+
 # Capture and Restore argument constants
 capture_arg = 'capture'
 restore_arg = 'restore'

--- a/slmigrate/constants.py
+++ b/slmigrate/constants.py
@@ -82,7 +82,7 @@ repository_dict = {
     'name': "Repository",
     'directory_migration': True,
     'singlefile_migration': False,
-    'migration_dir': os.path.join(migration_dir, "FileIngestion"),
+    'migration_dir': os.path.join(migration_dir, "Respository"),
     'source_dir': os.path.join(program_file_dir, "National Instruments", "Shared", "Web Services", "NI", "repo_webservice", "files")
 }
 repository = SimpleNamespace(**repository_dict)
@@ -94,6 +94,24 @@ userdata_dict = {
     'singlefile_migration': False,
 }
 userdata = SimpleNamespace(**userdata_dict)
+
+notification_dict = {
+    'arg': 'notification',
+    'name': "Notification",
+    'directory_migration': False,
+    'singlefile_migration': False,
+}
+notification = SimpleNamespace(**notification_dict)
+
+states_dict = {
+    'arg': 'states',
+    'name': "SystemsStateManager",
+    'directory_migration': True,
+    'singlefile_migration': False,
+    'migration_dir': os.path.join(migration_dir, "SystemsStateManager"),
+    'source_dir': os.path.join(program_data_dir, "National Instruments", "Skyline", "Data", "SystemsStateManager")
+}
+states = SimpleNamespace(**states_dict)
 
 # Capture and Restore argument constants
 capture_arg = 'capture'

--- a/slmigrate/filehandler.py
+++ b/slmigrate/filehandler.py
@@ -2,6 +2,14 @@ from slmigrate import constants
 from distutils import dir_util
 import os
 import shutil
+import stat
+
+
+def remove_readonly(func, path, excinfo):
+    os.chmod(path, stat.S_IWRITE)
+    func(path)
+
+
 
 
 def determine_migration_dir(service):
@@ -12,7 +20,8 @@ def determine_migration_dir(service):
 def remove_dir(dir):
     if (os.path.isdir(dir)):
         # shutil.rmtree(dir)
-        dir_util.remove_tree(dir)
+        # dir_util.remove_tree(dir)
+        shutil.rmtree(dir, onerror=remove_readonly)
 
 
 def migrate_singlefile(service, action):

--- a/slmigrate/filehandler.py
+++ b/slmigrate/filehandler.py
@@ -10,8 +10,6 @@ def remove_readonly(func, path, excinfo):
     func(path)
 
 
-
-
 def determine_migration_dir(service):
     migration_dir = os.path.join(constants.migration_dir, service.name)
     return migration_dir
@@ -19,8 +17,6 @@ def determine_migration_dir(service):
 
 def remove_dir(dir):
     if (os.path.isdir(dir)):
-        # shutil.rmtree(dir)
-        # dir_util.remove_tree(dir)
         shutil.rmtree(dir, onerror=remove_readonly)
 
 
@@ -46,6 +42,5 @@ def migrate_dir(service, action):
         remove_dir(migratation_dir)
         shutil.copytree(service.source_dir, migratation_dir)
     elif action == constants.restore_arg:
-        # do we just delete the destination directory? Otherwise we can't migrate states
         remove_dir(service.source_dir)
         dir_util.copy_tree(migratation_dir, service.source_dir)

--- a/slmigrate/filehandler.py
+++ b/slmigrate/filehandler.py
@@ -11,7 +11,8 @@ def determine_migration_dir(service):
 
 def remove_dir(dir):
     if (os.path.isdir(dir)):
-        shutil.rmtree(dir)
+        # shutil.rmtree(dir)
+        dir_util.remove_tree(dir)
 
 
 def migrate_singlefile(service, action):

--- a/slmigrate/filehandler.py
+++ b/slmigrate/filehandler.py
@@ -9,7 +9,7 @@ def determine_migration_dir(service):
     return migration_dir
 
 
-def check_migration_dir(dir):
+def remove_dir(dir):
     if (os.path.isdir(dir)):
         shutil.rmtree(dir)
 
@@ -19,7 +19,7 @@ def migrate_singlefile(service, action):
         return
     migration_dir = determine_migration_dir(service)
     if action == constants.capture_arg:
-        check_migration_dir(migration_dir)
+        remove_dir(migration_dir)
         os.mkdir(migration_dir)
         singlefile_full_path = os.path.join(constants.program_data_dir, service.singlefile_source_dir, service.singlefile_to_migrate)
         shutil.copy(singlefile_full_path, migration_dir)
@@ -33,7 +33,9 @@ def migrate_dir(service, action):
         return
     migratation_dir = determine_migration_dir(service)
     if action == constants.capture_arg:
-        check_migration_dir(migratation_dir)
+        remove_dir(migratation_dir)
         shutil.copytree(service.source_dir, migratation_dir)
     elif action == constants.restore_arg:
+        # do we just delete the destination directory? Otherwise we can't migrate states
+        remove_dir(service.source_dir)
         dir_util.copy_tree(migratation_dir, service.source_dir)

--- a/test/test_slmigrate.py
+++ b/test/test_slmigrate.py
@@ -11,7 +11,7 @@ from test import test_constants
 
 def test_parse_arguments():
     parser = arghandler.parse_arguments(sys.argv[1:])
-    assert parser.parse_args(["--" + constants.tag.arg, "--" + constants.opc.arg, "--" + constants.testmonitor.arg, "--" + constants.alarmrule.arg, "--" + constants.opc.arg, "--" + constants.asset.arg, "--" + constants.repository.arg, "--" + constants.userdata.arg])
+    assert parser.parse_args(["--" + constants.tag.arg, "--" + constants.opc.arg, "--" + constants.testmonitor.arg, "--" + constants.alarmrule.arg, "--" + constants.opc.arg, "--" + constants.asset.arg, "--" + constants.repository.arg, "--" + constants.userdata.arg, "--" + constants.notification.arg, "--" + constants.states.arg])
 
 
 def test_double_action_args():

--- a/test/test_slmigrate.py
+++ b/test/test_slmigrate.py
@@ -11,7 +11,7 @@ from test import test_constants
 
 def test_parse_arguments():
     parser = arghandler.parse_arguments(sys.argv[1:])
-    assert parser.parse_args(["--" + constants.tag.arg, "--" + constants.opc.arg, "--" + constants.testmonitor.arg, "--" + constants.alarmrule.arg, "--" + constants.opc.arg, "--" + constants.asset.arg, "--" + constants.repository.arg])
+    assert parser.parse_args(["--" + constants.tag.arg, "--" + constants.opc.arg, "--" + constants.testmonitor.arg, "--" + constants.alarmrule.arg, "--" + constants.opc.arg, "--" + constants.asset.arg, "--" + constants.repository.arg, "--" + constants.userdata.arg])
 
 
 def test_double_action_args():


### PR DESCRIPTION
- Support for user data although more testing is needed since its not clear if users will have access to their migrated data. 
  - I need to test a migration between severs with the same ldap. 
- Support for states, but these cannot be migrated from R1 to R2
- Support for notifications
- Declining support for SMTP because this is better handled by configuration than data migrations. 