### PR TITLE
Changed argparse to use sub-parser commands capture/restore, and gave…

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -5,9 +5,9 @@ name: SystemLink Migrate application
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
   pull_request:
-    branches: [ master ]
+    branches: [ main ]
 
 jobs:
   build:

--- a/slmigrate/arghandler.py
+++ b/slmigrate/arghandler.py
@@ -20,10 +20,10 @@ def parse_arguments():
     parent_parser.add_argument("--" + constants.migration_arg, "--directory", "--folder", help="Specify the directory used for migrated data", action="store", default=constants.migration_dir)
     parent_parser.add_argument("--" + constants.source_db_arg, "--sourcedb", help="The name of the source directory when performing intra-databse migration", action="store", default=constants.source_db)
 
-    commands = parser.add_subparsers(dest='action')
+    commands = parser.add_subparsers(dest=constants.subparser_storage_attr)
     commands.add_parser(constants.capture_arg, help="capture is used to pull data and settings off SystemLink server", parents=[parent_parser])
     commands.add_parser(constants.restore_arg, help="restore is used to push data and settings to a clean SystemLink server. ", parents=[parent_parser])
-  
+
     commands.add_parser(constants.thdbbug.arg, help="Migrate tag history data to the correct MongoDB to resolve an issue introduced in SystemLink 2020R2 when using a remote Mongo instance. Use --sourcedb to specify a source database. admin is used if none is specfied",)
 
     return parser
@@ -33,7 +33,7 @@ def determine_migrate_action(arguments):
     services_to_migrate = []
     action = arguments.action
     for arg in vars(arguments):
-        if (getattr(arguments, arg) and not (arg == 'action') and not (arg == constants.source_db_arg) and not (arg == constants.migration_arg)):
+        if (getattr(arguments, arg) and not (arg == constants.subparser_storage_attr) and not (arg == constants.source_db_arg) and not (arg == constants.migration_arg)):
             service = getattr(constants, arg)
             services_to_migrate.append((service, action))
 

--- a/slmigrate/arghandler.py
+++ b/slmigrate/arghandler.py
@@ -3,50 +3,43 @@ from slmigrate import constants
 
 
 # Setup available command line arguments
-def parse_arguments(args):
-    parser = argparse.ArgumentParser()
-    parser.add_argument("--" + constants.capture_arg, help="capture is used to pull data and settings off SystemLink server", action="store_true", )
-    parser.add_argument("--" + constants.restore_arg, help="restore is used to push data and settings to a clean SystemLink server. ", action="store_true", )
-    parser.add_argument("--" + constants.tag.arg, "--tags", "--tagingestion", "--taghistory", help="Migrate tags and tag histories", action="store_true", )
-    parser.add_argument("--" + constants.opc.arg, "--opcua", "--opcuaclient", help="Migrate OPCUA sessions and certificates", action="store_true")
-    parser.add_argument("--" + constants.fis.arg, "--file", "--files", help="Migrate ingested files", action="store_true")
-    parser.add_argument("--" + constants.testmonitor.arg, "--test", "--tests", "--testmonitor", help="Migrate Test Monitor data", action="store_true")
-    parser.add_argument("--" + constants.asset.arg, "--assets", help="Migrate asset utilitization and calibration data", action="store_true")
-    parser.add_argument("--" + constants.repository.arg, "--repo", help="Migrate packages and feeds", action="store_true")
-    parser.add_argument("--" + constants.alarmrule.arg, "--alarms", "--alarm", help="Migrate Tag alarm rules", action="store_true")
-    parser.add_argument("--" + constants.userdata.arg, "--ud", help="Migrate user data", action="store_true")
-    parser.add_argument("--" + constants.notification.arg, "--notifications", help="Migrate notifications strategies, templates, and groups", action="store_true")
-    parser.add_argument("--" + constants.states.arg, "--state", help="Migrate system states", action="store_true")
-    parser.add_argument("--" + constants.migration_arg, "--directory", "--folder", help="Specify the directory used for migrated data", action="store", default=constants.migration_dir)
-    parser.add_argument("--" + constants.thdbbug.arg, help="Migrate tag history data to the correct MongoDB to resolve an issue introduced in SystemLink 2020R2 when using a remote Mongo instance. Use --sourcedb to specify a source database. admin is used if none is specfied", action="store_true")
-    parser.add_argument("--" + constants.source_db_arg, "--sourcedb", help="The name of the source directory when performing intra-databse migration", action="store", default=constants.source_db)
+def parse_arguments():
+    parser = argparse.ArgumentParser(prog='slmigrate')
+
+    parent_parser = argparse.ArgumentParser(add_help=False)
+    parent_parser.add_argument("--" + constants.tag.arg, "--tags", "--tagingestion", "--taghistory", help="Migrate tags and tag histories", action="store_true", )
+    parent_parser.add_argument("--" + constants.opc.arg, "--opcua", "--opcuaclient", help="Migrate OPCUA sessions and certificates", action="store_true")
+    parent_parser.add_argument("--" + constants.fis.arg, "--file", "--files", help="Migrate ingested files", action="store_true")
+    parent_parser.add_argument("--" + constants.testmonitor.arg, "--test", "--tests", "--testmonitor", help="Migrate Test Monitor data", action="store_true")
+    parent_parser.add_argument("--" + constants.asset.arg, "--assets", help="Migrate asset utilitization and calibration data", action="store_true")
+    parent_parser.add_argument("--" + constants.repository.arg, "--repo", help="Migrate packages and feeds", action="store_true")
+    parent_parser.add_argument("--" + constants.alarmrule.arg, "--alarms", "--alarm", help="Migrate Tag alarm rules", action="store_true")
+    parent_parser.add_argument("--" + constants.userdata.arg, "--ud", help="Migrate user data", action="store_true")
+    parent_parser.add_argument("--" + constants.notification.arg, "--notifications", help="Migrate notifications strategies, templates, and groups", action="store_true")
+    parent_parser.add_argument("--" + constants.states.arg, "--state", help="Migrate system states", action="store_true")
+    parent_parser.add_argument("--" + constants.migration_arg, "--directory", "--folder", help="Specify the directory used for migrated data", action="store", default=constants.migration_dir)
+    parent_parser.add_argument("--" + constants.source_db_arg, "--sourcedb", help="The name of the source directory when performing intra-databse migration", action="store", default=constants.source_db)
+
+    commands = parser.add_subparsers(dest='action')
+    commands.add_parser(constants.capture_arg, help="capture is used to pull data and settings off SystemLink server", parents=[parent_parser])
+    commands.add_parser(constants.restore_arg, help="restore is used to push data and settings to a clean SystemLink server. ", parents=[parent_parser])
+  
+    commands.add_parser(constants.thdbbug.arg, help="Migrate tag history data to the correct MongoDB to resolve an issue introduced in SystemLink 2020R2 when using a remote Mongo instance. Use --sourcedb to specify a source database. admin is used if none is specfied",)
+
     return parser
-
-
-def handle_unallowed_args(arguments):
-    if arguments.thdbbug:
-        print("Moving tag history into correct databse. All other arguments will be ignored.")
-        return
-    if not(arguments.capture) and not(arguments.restore):
-        print("Please use --capture or --restore to determine which direction the migration is occuring.")
-        exit()
-    if arguments.capture and arguments.restore:
-        print("You cannot use --capture and --restore simultaneously.")
-        exit()
 
 
 def determine_migrate_action(arguments):
     services_to_migrate = []
-    if arguments.thdbbug:
-        action = constants.thdbbug.arg
-    if arguments.capture:
-        action = constants.capture_arg
-    elif arguments.restore:
-        action = constants.restore_arg
+    action = arguments.action
     for arg in vars(arguments):
-        if (getattr(arguments, arg) and not ((arg == constants.capture_arg) or (arg == constants.restore_arg) or (arg == constants.migration_arg) or (arg == constants.source_db_arg))):
+        if (getattr(arguments, arg) and not (arg == 'action') and not (arg == constants.source_db_arg) and not (arg == constants.migration_arg)):
             service = getattr(constants, arg)
             services_to_migrate.append((service, action))
+
+    # Special case for thdbbug, since there are no services given on the command line.
+    if action == constants.thdbbug.arg:
+        services_to_migrate.append((constants.tag, action))
     return services_to_migrate
 
 
@@ -56,3 +49,4 @@ def determine_migration_dir(arguments):
 
 def determine_source_db(arguments):
     constants.source_db = getattr(arguments, constants.source_db_arg)
+

--- a/slmigrate/constants.py
+++ b/slmigrate/constants.py
@@ -21,6 +21,8 @@ mongo_config = os.path.join(program_data_dir, "National Instruments", "Skyline",
 
 service_config_dir = config_file = os.path.join(program_data_dir, "National Instruments", "Skyline", "Config")
 
+# Global constants for argparse
+subparser_storage_attr = 'action'
 
 # Service Dictionaries
 tag_dict = {

--- a/systemlinkmigrate.py
+++ b/systemlinkmigrate.py
@@ -6,8 +6,7 @@ from slmigrate import mongohandler, filehandler, arghandler, servicemgrhandler, 
 
 # Main
 if __name__ == "__main__":
-    arguments = arghandler.parse_arguments(sys.argv[1:]).parse_args()
-    arghandler.handle_unallowed_args(arguments)
+    arguments = arghandler.parse_arguments().parse_args()
     arghandler.determine_migration_dir(arguments)
     arghandler.determine_source_db(arguments)
     servicemgrhandler.stop_all_sl_services()

--- a/test/test_slmigrate.py
+++ b/test/test_slmigrate.py
@@ -10,38 +10,54 @@ from test import test_constants
 
 
 def test_parse_arguments():
-    parser = arghandler.parse_arguments(sys.argv[1:])
-    assert parser.parse_args(["--" + constants.tag.arg, "--" + constants.opc.arg, "--" + constants.testmonitor.arg, "--" + constants.alarmrule.arg, "--" + constants.opc.arg, "--" + constants.asset.arg, "--" + constants.repository.arg, "--" + constants.userdata.arg, "--" + constants.notification.arg, "--" + constants.states.arg])
+    parser = arghandler.parse_arguments()
+    assert parser.parse_args([constants.capture_arg,
+                              "--" + constants.tag.arg,
+                              "--" + constants.opc.arg,
+                              "--" + constants.testmonitor.arg,
+                              "--" + constants.alarmrule.arg,
+                              "--" + constants.opc.arg,
+                              "--" + constants.asset.arg,
+                              "--" + constants.repository.arg,
+                              "--" + constants.userdata.arg,
+                              "--" + constants.notification.arg,
+                              "--" + constants.states.arg])
 
 
 def test_double_action_args():
-    parser = arghandler.parse_arguments(sys.argv[1:])
-    arguments = parser.parse_args(["--" + constants.capture_arg, "--" + constants.restore_arg])
+    parser = arghandler.parse_arguments()
     with pytest.raises(SystemExit) as pytest_wrapped_e:
-        arghandler.handle_unallowed_args(arguments)
+        parser.parse_args([constants.capture_arg, constants.restore_arg])
     assert pytest_wrapped_e.type == SystemExit
 
 
 def test_no_action_args():
-    parser = arghandler.parse_arguments(2)
-    arguments = parser.parse_args(["--" + constants.tag.arg])
+    parser = arghandler.parse_arguments()
     with pytest.raises(SystemExit) as pytest_wrapped_e:
-        arghandler.handle_unallowed_args(arguments)
+        parser.parse_args(["--" + constants.tag.arg])
     assert pytest_wrapped_e.type == SystemExit
 
 
 def test_determine_migrate_action_capture():
     test_service_tuple = [(constants.tag, constants.capture_arg)]
-    parser = arghandler.parse_arguments(sys.argv[1:])
-    arguments = parser.parse_args(["--" + constants.tag.arg, "--" + constants.capture_arg])
+    parser = arghandler.parse_arguments()
+    arguments = parser.parse_args([constants.capture_arg, "--" + constants.tag.arg])
     services_to_migrate = arghandler.determine_migrate_action(arguments)
     assert services_to_migrate == test_service_tuple
 
 
 def test_determine_migrate_action_restore():
-    test_service_tuple = [(constants.opc, constants.capture_arg)]
-    parser = arghandler.parse_arguments(sys.argv[1:])
-    arguments = parser.parse_args(["--" + constants.opc.arg, "--" + constants.capture_arg])
+    test_service_tuple = [(constants.opc, constants.restore_arg)]
+    parser = arghandler.parse_arguments()
+    arguments = parser.parse_args([constants.restore_arg, "--" + constants.opc.arg])
+    services_to_migrate = arghandler.determine_migrate_action(arguments)
+    assert services_to_migrate == test_service_tuple
+
+
+def test_determine_migrate_action_thdbbg():
+    test_service_tuple = [(constants.tag, constants.thdbbug.arg)]
+    parser = arghandler.parse_arguments()
+    arguments = parser.parse_args([constants.thdbbug.arg])
     services_to_migrate = arghandler.determine_migrate_action(arguments)
     assert services_to_migrate == test_service_tuple
 
@@ -102,3 +118,4 @@ def test_capture_migrate_singlefile():
     assert os.path.isfile(os.path.join(test.migration_dir, "demofile2.txt"))
     shutil.rmtree(test.source_dir)
     shutil.rmtree(constants.migration_dir)
+


### PR DESCRIPTION
… them a parent parser that they share the same arguments.  thdbbug is treated as a separate command with no parent.  Modified tests to account for slightly different calling convention, the command must come before the arguments for it.